### PR TITLE
feature/Monster-avatar

### DIFF
--- a/ConsoleRPG/ConsoleRPG.vcxproj
+++ b/ConsoleRPG/ConsoleRPG.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="CRItem.cpp" />
     <ClCompile Include="CRMage.cpp" />
     <ClCompile Include="CRMain.cpp" />
+    <ClCompile Include="Enemy\Monster\Boss\CRDragon.cpp" />
     <ClCompile Include="Enemy\Monster\Enum\CRMonsterType.h" />
     <ClCompile Include="Enemy\Monster\Factory\CRMonsterFactory.cpp" />
     <ClCompile Include="CROrangePotion.cpp" />
@@ -165,6 +166,7 @@
     <ClInclude Include="CRGameManager.h" />
     <ClInclude Include="CRGameMode.h" />
     <ClInclude Include="CRGameSystem.h" />
+    <ClInclude Include="Enemy\Monster\Boss\CRDragon.h" />
     <ClInclude Include="Enemy\Monster\Factory\CRMonsterFactory.h" />
     <ClInclude Include="CRInventory.h" />
     <ClInclude Include="CRItem.h" />

--- a/ConsoleRPG/Enemy/Monster/Boss/CRDragon.cpp
+++ b/ConsoleRPG/Enemy/Monster/Boss/CRDragon.cpp
@@ -1,0 +1,9 @@
+﻿#include "CRDragon.h"
+
+Dragon::Dragon(int level, int uniqueId)  : MonsterBase("드레곤", uniqueId)
+{
+    Name = "Dragon";
+    CurrentHealth = 4000;
+    MonsterDamage = 100;
+    MonsterAttribute = EMonsterAttribute::EMA_Fire;
+}

--- a/ConsoleRPG/Enemy/Monster/Boss/CRDragon.h
+++ b/ConsoleRPG/Enemy/Monster/Boss/CRDragon.h
@@ -6,11 +6,3 @@ class Dragon : public MonsterBase
 public:
     Dragon(int level, int uniqueId);
 };
-
-
-// class Orc : public MonsterBase {
-// public:
-//     Orc(int level, int uniqueId);
-// };
-
-

--- a/ConsoleRPG/Enemy/Monster/Boss/CRDragon.h
+++ b/ConsoleRPG/Enemy/Monster/Boss/CRDragon.h
@@ -1,0 +1,16 @@
+﻿#pragma once
+#include "../Interface/CRMonsterBase.h"
+
+class Dragon : public MonsterBase
+{
+public:
+    Dragon(int level, int uniqueId);
+};
+
+
+// class Orc : public MonsterBase {
+// public:
+//     Orc(int level, int uniqueId);
+// };
+
+

--- a/ConsoleRPG/Enemy/Monster/Enum/CRMonsterType.h
+++ b/ConsoleRPG/Enemy/Monster/Enum/CRMonsterType.h
@@ -20,5 +20,36 @@ enum class EMonsterType
   EMT_Goblin,
 
   /* 슬라임 */
-  EMT_Slime
+  EMT_Slime,
+
+  EMT_Dragon
+};
+
+/**
+ * @brief 몬스터 속성을 정의하는 열거형
+ *
+ * 게임 내의 몬스터들이 가질 수 있는 다양한 속성을 정의합니다.
+ * 각 속성은 특정 특성과 상호작용을 나타내며, 전투 및 게임 메커니즘에 영향을 미칠 수 있습니다.
+ *
+ * @note 속성은 몬스터의 공격이나 방어, 특정 조건에서의 성능에 영향을 줄 수 있습니다.
+ */
+enum class EMonsterAttribute
+{
+  /* 속성없음 */
+  EMA_None,
+
+  /* 불속성 */
+  EMA_Fire,
+
+  /* 물속성 */
+  EMA_Water,
+
+  /* 땅속성 */
+  EMA_Earth,
+
+  /* 바람속성 */
+  EMA_Wind,
+
+  /* 독속성 */
+  EMA_Poison
 };

--- a/ConsoleRPG/Enemy/Monster/Factory/CRMonsterFactory.cpp
+++ b/ConsoleRPG/Enemy/Monster/Factory/CRMonsterFactory.cpp
@@ -3,6 +3,7 @@
 #include "../Goblin/CRGoblin.h"
 #include "../Orc/CROrc.h"
 #include "../Slime/CRSlime.h"
+#include "../Boss/CRDragon.h"
 
 
 /**
@@ -29,6 +30,9 @@ std::shared_ptr<MonsterBase> CRMonsterFactory::CreateMonster(EMonsterType monste
 
   case EMonsterType::EMT_Slime:
     return std::make_shared<Slime>(level);
+
+  case EMonsterType::EMT_Dragon:
+    return std::make_shared<Dragon>(level, uniqueId);
   
   default:
     return nullptr;

--- a/ConsoleRPG/Enemy/Monster/Factory/CRMonsterFactory.h
+++ b/ConsoleRPG/Enemy/Monster/Factory/CRMonsterFactory.h
@@ -18,7 +18,7 @@ public:
     static std::shared_ptr<MonsterBase> CreateMonster(EMonsterType monsterType, int level, int uniqueId);
 
 private:
-  /** @brief 팩토리 클래스의 인스턴스화를 방지하기 위한 private 생성자 */
-  CRMonsterFactory() = default;
+    /** @brief 팩토리 클래스의 인스턴스화를 방지하기 위한 private 생성자 */
+    CRMonsterFactory() = default;
 
 };

--- a/ConsoleRPG/Enemy/Monster/Interface/CRMonsterBase.cpp
+++ b/ConsoleRPG/Enemy/Monster/Interface/CRMonsterBase.cpp
@@ -1,1 +1,38 @@
 ﻿#include "CRMonsterBase.h"
+
+std::string MonsterBase::GetName() const noexcept
+{
+    return Name;
+}
+
+int MonsterBase::GetCurrentMonsterHealth() const noexcept
+{
+    return CurrentHealth;
+}
+
+int MonsterBase::GetMaxMonsterHealth() const noexcept
+{
+    return MaxHealth;
+}
+
+void MonsterBase::TakeDamage(int value)
+{
+    CurrentHealth = std::clamp(CurrentHealth - value, 0, MaxHealth);
+    cout << "TakeDamage: " << value << endl;
+    cout << "CurrentHP: " << CurrentHealth << endl;
+}
+
+void MonsterBase::Attack()
+{
+    Singleton<CREventManager<int>>::GetInstance().Broadcast(EEventType::EET_CharacterTakeDamage, MonsterDamage);
+}
+
+MonsterHealthInfo MonsterBase::GetHealthInfo() const noexcept
+{
+    return { CurrentHealth, MaxHealth };
+}
+
+int MonsterBase::GetUniqueId() const
+{
+    return UniqueId;
+}

--- a/ConsoleRPG/Enemy/Monster/Interface/CRMonsterBase.h
+++ b/ConsoleRPG/Enemy/Monster/Interface/CRMonsterBase.h
@@ -4,6 +4,7 @@
 #include "../../../Singleton.h"
 #include "../../../CREventManager.h"
 #include "../Struct/CRMonsterHealthInfo.h"
+#include "../Enum/CRMonsterType.h"
 #include "IMonster.h"
 #include <string>
 #include <algorithm>
@@ -33,6 +34,7 @@ private:
     static constexpr int DEFAULT_HEALTH = 100;
     // @brief 기본 공격력 상수
     static constexpr int DEFAULT_DAMAGE = 10;
+    static constexpr EMonsterAttribute DEFAULT_ATTRIBUTE = EMonsterAttribute::EMA_None;
 
 protected:
     std::string Name; //< 몬스터의 이름
@@ -40,6 +42,7 @@ protected:
     int CurrentHealth; //< 현재 체력
     int MaxHealth; //< 최대 체력
     int MonsterDamage; //< 공격력
+    EMonsterAttribute MonsterAttribute; // < 속성
     
 
 public:
@@ -50,11 +53,12 @@ public:
      * @note 모든 기본 스탯은 상수값으로 초기화됩니다
      */
     explicit MonsterBase(const std::string& monsterName = "", const int& uniqueId = 0)
-        : Name(monsterName)
-        , UniqueId(uniqueId)
-        , CurrentHealth(DEFAULT_HEALTH)
-        , MaxHealth(DEFAULT_HEALTH)
-        , MonsterDamage(DEFAULT_DAMAGE)
+        : Name(monsterName),
+        UniqueId(uniqueId),
+        CurrentHealth(DEFAULT_HEALTH),
+        MaxHealth(DEFAULT_HEALTH),
+        MonsterDamage(DEFAULT_DAMAGE),
+        MonsterAttribute(DEFAULT_ATTRIBUTE)
     {
     }
 
@@ -81,10 +85,8 @@ public:
      * @return std::string 몬스터의 이름
      * @note 이 메서드는 예외를 발생시키지 않습니다
      */
-    std::string GetName() const noexcept override
-    {
-        return Name;
-    }
+    std::string GetName() const noexcept override;
+
 
     /**
      * @brief 몬스터의 현재 체력을 반환
@@ -92,10 +94,7 @@ public:
      * @return int 현재 체력값
      * @note 이 메서드는 예외를 발생시키지 않습니다
      */
-    int GetCurrentMonsterHealth() const noexcept override
-    {
-        return CurrentHealth;
-    }
+    int GetCurrentMonsterHealth() const noexcept override;
 
     /**
      * @brief 몬스터의 최대 체력을 반환
@@ -103,10 +102,7 @@ public:
      * @return int 최대 체력값
      * @note 이 메서드는 예외를 발생시키지 않습니다
      */
-    int GetMaxMonsterHealth() const noexcept override
-    {
-        return MaxHealth;
-    }
+    int GetMaxMonsterHealth() const noexcept override;
 
     /**
      * @brief 몬스터가 데미지를 받는 함수
@@ -115,11 +111,7 @@ public:
      * @note 음수 데미지는 무시됩니다
      * @note 체력은 0과 최대체력 사이로 제한됩니다
      */
-    void TakeDamage(int value) override {
-        CurrentHealth = std::clamp(CurrentHealth - value, 0, MaxHealth);
-        cout << "TakeDamage: " << value << endl;
-        cout << "CurrentHP: " << CurrentHealth << endl;
-    }
+    void TakeDamage(int value) override;
 
     /**
      * @brief 몬스터의 공격 함수
@@ -128,12 +120,7 @@ public:
      * @note EET_CharacterTakeDamage 이벤트를 발생시킵니다
      * @see CREventManager
      */
-    void Attack() override {
-        Singleton<CREventManager<int>>::GetInstance().Broadcast(
-            EEventType::EET_CharacterTakeDamage, 
-            MonsterDamage
-        );
-    }
+    void Attack() override;
     
 
     /**
@@ -142,13 +129,13 @@ public:
      * @return HealthInfo + CurrentHealth, MaxHealth (현재 체력과 최대 체력을 포함한 구조체)
      * @note 이 메서드는 예외를 발생시키지 않습니다
      */
-    MonsterHealthInfo GetHealthInfo() const noexcept
-    {
-        return { CurrentHealth, MaxHealth };
-    }
+    MonsterHealthInfo GetHealthInfo() const noexcept;
 
-    inline int GetUniqueId() const
-    {
-        return UniqueId;
-    }
+    /**
+     * @brief 몬스터의 고유 식별자를 반환합니다.
+     *
+     * @return int 고유 식별자 (UniqueId)
+     * @note 이 메서드는 예외를 발생시키지 않습니다.
+     */
+    inline int GetUniqueId() const;
 };

--- a/ConsoleRPG/Enemy/Monster/Orc/CROrc.cpp
+++ b/ConsoleRPG/Enemy/Monster/Orc/CROrc.cpp
@@ -1,8 +1,8 @@
 ﻿#include "CROrc.h"
-#include "../../../Singleton.h"
 
 Orc::Orc(int level, int uniqueId) : MonsterBase("오크", uniqueId) {
   Name = "Orc";
   CurrentHealth = 50 + level * 7;
   MonsterDamage = 10 + level * 2;
+  MonsterAttribute = EMonsterAttribute::EMA_Fire;
 }

--- a/ConsoleRPG/Enemy/Monster/Slime/CRSlime.cpp
+++ b/ConsoleRPG/Enemy/Monster/Slime/CRSlime.cpp
@@ -1,9 +1,9 @@
 ﻿#include "CRSlime.h"
-#include "../../../Singleton.h"
 
 Slime::Slime(int level)
 {
   Name = "Slime";
   CurrentHealth = 70 + level * 10;
   MonsterDamage = 8 + level * 3;
+  MonsterAttribute = EMonsterAttribute::EMA_Poison;
 }

--- a/ConsoleRPG/Enemy/Monster/Troll/Troll.cpp
+++ b/ConsoleRPG/Enemy/Monster/Troll/Troll.cpp
@@ -5,4 +5,5 @@ Troll::Troll(int level)
     Name = "Troll";
     CurrentHealth = 70 + level * 10;
     MonsterDamage = 8 + level * 3;
+    MonsterAttribute = EMonsterAttribute::EMA_Earth;
 }


### PR DESCRIPTION
드래곤 보스를 추가하고 몬스터 속성 지원을 강화함

- 불 속성을 지닌 드래곤 몬스터를 도입하여 게임의 몬스터 다양성을 확장하고 보스 타입 적을 추가함.
- 몬스터의 속성(Elemental Attribute)을 지원하도록 MonsterBase 클래스를 리팩토링하고, 기존 몬스터들에도 적절한 속성을 부여함.
- 새로운 변경 사항이 자연스럽게 통합되도록 팩토리 및 관련 코드도 함께 수정함.